### PR TITLE
Change root page to note creation view

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,45 @@
 import Head from 'next/head'
-import styles from '../styles/Home.module.css'
+import { useState, FormEvent, useEffect } from 'react'
 
 export default function Home() {
+  const [content, setContent] = useState('')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem('new-note-content')
+    if (saved) {
+      setContent(saved)
+    }
+  }, [])
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    window.localStorage.setItem('new-note-content', content)
+    setMessage('保存しました（ローカル保存）')
+  }
+
   return (
-    <div className={styles.container}>
+    <div className="max-w-xl mx-auto">
       <Head>
         <title>Simplenotebook</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <h1 className={styles.title}>Hello, Next.js!</h1>
+      <h1 className="text-2xl font-bold mb-4">新規ノート</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <textarea
+          className="w-full border rounded p-2 h-40"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="Markdownを書いてください"
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          保存
+        </button>
+        {message && <p className="text-green-600">{message}</p>}
+      </form>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace Next.js starter home page with the new note form

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e42e2f45483288ddc881e6b0fa0c1