### PR TITLE
Make textarea fullscreen

### DIFF
--- a/app/notes/new/page.tsx
+++ b/app/notes/new/page.tsx
@@ -23,7 +23,7 @@ export default function NewNotePage() {
       <h1 className="text-2xl font-bold mb-4">新規ノート</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <textarea
-          className="w-full border rounded p-2 h-40"
+          className="w-screen h-screen border rounded p-2"
           value={content}
           onChange={e => setContent(e.target.value)}
           placeholder="Markdownを書いてください"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ export default function Home() {
       <h1 className="text-2xl font-bold mb-4">新規ノート</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <textarea
-          className="w-full border rounded p-2 h-40"
+          className="w-screen h-screen border rounded p-2"
           value={content}
           onChange={e => setContent(e.target.value)}
           placeholder="Markdownを書いてください"


### PR DESCRIPTION
## Summary
- extend the textarea to fill the viewport using `w-screen h-screen` in Tailwind

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e55386f588328923518957927dc66