### PR TITLE
fix(e2e): 初回設定モーダルによるテストブロックを解消

### DIFF
--- a/tests/basic-functionality.spec.ts
+++ b/tests/basic-functionality.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
 
 test.describe('Simplenotebook Basic Functionality', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedUserSettings(page);
+  });
+
   test('should load the main page and redirect to /notes/new', async ({ page }) => {
     // Go to the root page and wait for network to be idle
     await page.goto('/', { waitUntil: 'networkidle' });

--- a/tests/dev-server-functionality.spec.ts
+++ b/tests/dev-server-functionality.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
 
 test.describe('Simplenotebook - Development Server', () => {
   const DEV_BASE_URL = 'http://localhost:3001/simplenotebook';
-  
+
   test.beforeEach(async ({ page }) => {
     // Set a longer timeout for development server tests
     page.setDefaultTimeout(10000);
+    await seedUserSettings(page);
   });
 
   test('should display the application title', async ({ page }) => {

--- a/tests/fixed-selectors.spec.ts
+++ b/tests/fixed-selectors.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
 
 test.describe('Simplenotebook - Fixed Selectors', () => {
   const DEV_BASE_URL = 'http://localhost:3001/simplenotebook';
-  
+
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
+    await seedUserSettings(page);
   });
 
   test('should display the application title', async ({ page }) => {

--- a/tests/helpers/seedUserSettings.ts
+++ b/tests/helpers/seedUserSettings.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+
+/**
+ * ローカルモードの初回設定モーダルが表示されないよう、
+ * ページ読み込み前に userSettings を localStorage にシードする。
+ */
+export async function seedUserSettings(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'userSettings',
+      JSON.stringify({
+        displayName: 'テストユーザー',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  });
+}

--- a/tests/initial-settings-modal.spec.ts
+++ b/tests/initial-settings-modal.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Initial Settings Modal', () => {
+  test('should show the initial settings modal when userSettings is missing and save it', async ({ page }) => {
+    // userSettings をシードしない状態でアクセスし、初回設定モーダルが表示されることを確認
+    await page.goto('/notes/new', { waitUntil: 'networkidle' });
+
+    const modal = page.locator('div[role="dialog"][aria-modal="true"]');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await expect(modal.locator('#modal-title')).toContainText('初回設定');
+
+    // 表示名を入力して保存
+    await modal.locator('#displayName').fill('テストユーザー');
+    await modal.locator('button[type="submit"]').click();
+
+    // 保存後はモーダルが閉じ、/notes/new に遷移する
+    await expect(modal).not.toBeVisible({ timeout: 10000 });
+    await page.waitForURL('**/notes/new', { timeout: 10000 });
+
+    // localStorage に userSettings が保存されていることを確認
+    const savedSettings = await page.evaluate(() => localStorage.getItem('userSettings'));
+    expect(savedSettings).not.toBeNull();
+    expect(JSON.parse(savedSettings!)).toMatchObject({ displayName: 'テストユーザー' });
+  });
+});

--- a/tests/initial-settings-modal.spec.ts
+++ b/tests/initial-settings-modal.spec.ts
@@ -3,7 +3,9 @@ import { test, expect } from '@playwright/test';
 test.describe('Initial Settings Modal', () => {
   test('should show the initial settings modal when userSettings is missing and save it', async ({ page }) => {
     // userSettings をシードしない状態でアクセスし、初回設定モーダルが表示されることを確認
-    await page.goto('/notes/new', { waitUntil: 'networkidle' });
+    // baseURL に basePath ('/simplenotebook') が含まれる場合、先頭 '/' の相対パスは
+    // basePath を無視してしまうため、basePath を含む絶対パスで遷移する
+    await page.goto('/simplenotebook/notes/new', { waitUntil: 'networkidle' });
 
     const modal = page.locator('div[role="dialog"][aria-modal="true"]');
     await expect(modal).toBeVisible({ timeout: 10000 });

--- a/tests/note-management.spec.ts
+++ b/tests/note-management.spec.ts
@@ -4,7 +4,9 @@ import { seedUserSettings } from './helpers/seedUserSettings';
 test.describe('Note Management Features', () => {
   test.beforeEach(async ({ page }) => {
     await seedUserSettings(page);
-    await page.goto('/notes/new');
+    // baseURL に basePath ('/simplenotebook') が含まれる場合、先頭 '/' の相対パスは
+    // basePath を無視してしまうため、basePath を含む絶対パスで遷移する
+    await page.goto('/simplenotebook/notes/new');
     // Wait for page to be fully loaded
     await expect(page.locator('h1')).toContainText('SimpleNotebook');
   });

--- a/tests/note-management.spec.ts
+++ b/tests/note-management.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
 
 test.describe('Note Management Features', () => {
   test.beforeEach(async ({ page }) => {
+    await seedUserSettings(page);
     await page.goto('/notes/new');
     // Wait for page to be fully loaded
     await expect(page.locator('h1')).toContainText('SimpleNotebook');


### PR DESCRIPTION
## Summary
- ローカルモードでは userSettings が localStorage に無いと `AuthGuard` が初回設定モーダルを表示し、オーバーレイがクリックをブロックしてしまう
- `basic-functionality` / `note-management` / `dev-server-functionality` / `fixed-selectors` の各 `beforeEach` で `page.addInitScript()` により `userSettings` をシードする共通ヘルパー `tests/helpers/seedUserSettings.ts` を追加
- 初回設定モーダル自体の表示・保存フローをカバーする専用テスト `tests/initial-settings-modal.spec.ts` を追加

## Test plan
- [x] `tests/dev-server-functionality.spec.ts` / `tests/fixed-selectors.spec.ts` をローカルの dev サーバー (port 3001) に対して実行し、モーダルによる `intercepts pointer events` エラーが解消されたことを確認
- 注: `basic-functionality` / `note-management` はベース URL とポートの不整合 (#62 の対象) により手元では完全な自動起動検証ができなかったが、失敗内容はすべて接続/ルーティング起因でありモーダルブロックは再現しなかった
- [x] `tests/initial-settings-modal.spec.ts` を実行し、初回設定モーダルの表示〜保存〜localStorage永続化フローを確認

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)