### PR TITLE
feat: ノート検索機能の追加 (B-01)

### DIFF
--- a/app/notes/new/page.tsx
+++ b/app/notes/new/page.tsx
@@ -3,8 +3,10 @@ import { useState, FormEvent, useEffect, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useAuth } from '../../../hooks/useAuth'
 import { useNotes } from '../../../hooks/useNotes'
+import { useNoteSearch } from '../../../hooks/useNoteSearch'
 import { getUserDisplayName } from '../../../utils/userDisplay'
 import UserDisplay from '../../../components/UserDisplay'
+import SearchBox from '../../../components/SearchBox'
 
 function NewNotePageContent() {
   const [content, setContent] = useState('')
@@ -20,6 +22,7 @@ function NewNotePageContent() {
   const router = useRouter()
   const { user, signOut, isLocal } = useAuth()
   const { notes, loading, error, createNote, updateNote, deleteNote, getNote, fetchNotes } = useNotes()
+  const { query, setQuery, filteredNotes, isSearching } = useNoteSearch(notes, getNote)
 
   // Handle OAuth callback
   useEffect(() => {
@@ -260,7 +263,9 @@ function NewNotePageContent() {
               更新
             </button>
           </div>
-          
+
+          <SearchBox value={query} onChange={setQuery} />
+
           {loading && (
             <div className="text-center text-gray-500">
               ノートを読み込み中...
@@ -278,9 +283,15 @@ function NewNotePageContent() {
               まだノートがありません
             </div>
           )}
-          
+
+          {notes.length > 0 && filteredNotes.length === 0 && isSearching && (
+            <div className="text-gray-500 text-center" data-testid="search-no-results">
+              「{query}」に一致するノートはありません
+            </div>
+          )}
+
           <div className="space-y-2 max-h-96 overflow-y-auto">
-            {notes.map((note) => (
+            {filteredNotes.map((note) => (
               <div key={note.id} className="border rounded p-3 hover:bg-gray-50">
                 <div className="flex justify-between items-start">
                   <div className="flex-1">

--- a/components/SearchBox.tsx
+++ b/components/SearchBox.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+interface SearchBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function SearchBox({ value, onChange }: SearchBoxProps) {
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="ノートを検索..."
+        aria-label="ノートを検索"
+        className="w-full border rounded p-2 pr-8 text-sm bg-white"
+        data-testid="note-search"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label="検索をクリア"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/hooks/useNoteSearch.ts
+++ b/hooks/useNoteSearch.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { Note } from '../lib/api';
+
+type NoteSummary = Omit<Note, 'content'>;
+
+/**
+ * ノート一覧のクライアントサイド検索。
+ * 一覧 API は content を返さないため、検索開始時に本文を取得してキャッシュする。
+ * キャッシュキーに updatedAt を含めることで、更新されたノートは自動的に再取得される。
+ */
+export function useNoteSearch(
+  notes: NoteSummary[],
+  getNote: (id: string) => Promise<Note | null>
+) {
+  const [query, setQuery] = useState('');
+  const [contents, setContents] = useState<Record<string, string>>({});
+
+  const cacheKey = (note: NoteSummary) => `${note.id}:${note.updatedAt}`;
+
+  useEffect(() => {
+    if (!query.trim()) return;
+    const missing = notes.filter(note => !(cacheKey(note) in contents));
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        missing.map(async note => {
+          const full = await getNote(note.id);
+          return [cacheKey(note), full?.content ?? ''] as const;
+        })
+      );
+      if (!cancelled) {
+        setContents(prev => ({ ...prev, ...Object.fromEntries(entries) }));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, notes]);
+
+  const filteredNotes = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return notes;
+    return notes.filter(note =>
+      note.title.toLowerCase().includes(q) ||
+      (contents[cacheKey(note)] ?? '').toLowerCase().includes(q)
+    );
+  }, [query, notes, contents]);
+
+  return { query, setQuery, filteredNotes, isSearching: query.trim().length > 0 };
+}

--- a/hooks/useNoteSearch.ts
+++ b/hooks/useNoteSearch.ts
@@ -5,6 +5,18 @@ import { Note } from '../lib/api';
 
 type NoteSummary = Omit<Note, 'content'>;
 
+// 本文取得の同時実行数の上限。ノート数が多い場合に一括 Promise.all で
+// リクエストが膨らむのを避けるため、この件数ずつ区切って順に取得する。
+const FETCH_CHUNK_SIZE = 5;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 /**
  * ノート一覧のクライアントサイド検索。
  * 一覧 API は content を返さないため、検索開始時に本文を取得してキャッシュする。
@@ -20,20 +32,28 @@ export function useNoteSearch(
   const cacheKey = (note: NoteSummary) => `${note.id}:${note.updatedAt}`;
 
   useEffect(() => {
-    if (!query.trim()) return;
-    const missing = notes.filter(note => !(cacheKey(note) in contents));
+    const q = query.trim().toLowerCase();
+    if (!q) return;
+
+    // タイトルで既に一致しているノートは本文取得の対象から除く
+    const missing = notes.filter(
+      note => !note.title.toLowerCase().includes(q) && !(cacheKey(note) in contents)
+    );
     if (missing.length === 0) return;
 
     let cancelled = false;
     (async () => {
-      const entries = await Promise.all(
-        missing.map(async note => {
-          const full = await getNote(note.id);
-          return [cacheKey(note), full?.content ?? ''] as const;
-        })
-      );
-      if (!cancelled) {
-        setContents(prev => ({ ...prev, ...Object.fromEntries(entries) }));
+      for (const batch of chunk(missing, FETCH_CHUNK_SIZE)) {
+        if (cancelled) return;
+        const entries = await Promise.all(
+          batch.map(async note => {
+            const full = await getNote(note.id);
+            return [cacheKey(note), full?.content ?? ''] as const;
+          })
+        );
+        if (!cancelled) {
+          setContents(prev => ({ ...prev, ...Object.fromEntries(entries) }));
+        }
       }
     })();
     return () => {

--- a/tests/note-search.spec.ts
+++ b/tests/note-search.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, Page } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
+import { appPath } from './helpers/paths';
+
+async function createNote(page: Page, title: string, content: string) {
+  await page.fill('input[placeholder*="ノートのタイトル"]', title);
+  await page.fill('textarea[placeholder*="Markdownを書いてください"]', content);
+  await page.click('button[type="submit"]');
+  await expect(page.locator('text=ノートを保存しました（ローカル保存）')).toBeVisible();
+}
+
+test.describe('Note Search (B-01)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedUserSettings(page);
+    await page.goto(appPath('/notes/new'));
+    await expect(page.locator('h1')).toContainText('SimpleNotebook');
+    await createNote(page, '買い物リスト', '- 牛乳\n- パン');
+    await createNote(page, '会議メモ', '来週のスプリント計画について議論する');
+  });
+
+  test('タイトルでリアルタイムに絞り込める', async ({ page }) => {
+    const search = page.getByTestId('note-search');
+    await search.fill('買い物');
+
+    await expect(page.locator('h3', { hasText: '買い物リスト' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '会議メモ' })).not.toBeVisible();
+  });
+
+  test('本文でも検索できる', async ({ page }) => {
+    const search = page.getByTestId('note-search');
+    await search.fill('スプリント');
+
+    await expect(page.locator('h3', { hasText: '会議メモ' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '買い物リスト' })).not.toBeVisible();
+  });
+
+  test('0件時にメッセージが表示され、クリアで全件に戻る', async ({ page }) => {
+    const search = page.getByTestId('note-search');
+    await search.fill('存在しないキーワードXYZ');
+
+    await expect(page.getByTestId('search-no-results')).toBeVisible();
+
+    await page.click('button[aria-label="検索をクリア"]');
+    await expect(search).toHaveValue('');
+    await expect(page.locator('h3', { hasText: '買い物リスト' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '会議メモ' })).toBeVisible();
+  });
+});

--- a/tests/note-search.spec.ts
+++ b/tests/note-search.spec.ts
@@ -6,7 +6,9 @@ async function createNote(page: Page, title: string, content: string) {
   await page.fill('input[placeholder*="ノートのタイトル"]', title);
   await page.fill('textarea[placeholder*="Markdownを書いてください"]', content);
   await page.click('button[type="submit"]');
-  await expect(page.locator('text=ノートを保存しました（ローカル保存）')).toBeVisible();
+  // ローカル/リモート環境で成功メッセージの文言が異なる (「保存しました！」/「保存しました（ローカル保存）」) ため、
+  // 共通する部分文字列で判定する
+  await expect(page.locator('text=保存しました')).toBeVisible();
 }
 
 test.describe('Note Search (B-01)', () => {


### PR DESCRIPTION
Closes #68

## 概要
ノート一覧にタイトル・本文のリアルタイム検索を追加します。

## 変更内容
- `components/SearchBox.tsx`: 検索ボックス(クリアボタン付き)
- `hooks/useNoteSearch.ts`: 絞り込みロジック。一覧 API は本文を返さないため、検索開始時に本文を取得し `id:updatedAt` キーでキャッシュ(ノート更新時は自動再取得)
- `app/notes/new/page.tsx`: 検索ボックス組み込み、0件時メッセージ表示
- `tests/note-search.spec.ts`: E2E 3件(タイトル検索/本文検索/0件+クリア)

## テスト
- `npm run lint` ✅
- 新規 E2E 3件すべて成功 ✅
- ブラウザ実機確認: 本文キーワードでの絞り込み・クリアで全件復帰を確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)