### PR TITLE
fix: 既存 E2E テスト8件の失敗を修繕 (B-13)

### DIFF
--- a/tests/basic-functionality.spec.ts
+++ b/tests/basic-functionality.spec.ts
@@ -113,9 +113,9 @@ test.describe('Simplenotebook Basic Functionality', () => {
     // Wait for page to be loaded
     await page.waitForSelector('h1', { timeout: 10000 });
     
-    // Check for saved notes section
-    await expect(page.locator('h2')).toContainText('保存されたノート');
-    await expect(page.locator('button')).toContainText('更新');
+    // Check for saved notes section (h2/button は複数あるため hasText で特定する)
+    await expect(page.locator('h2').filter({ hasText: '保存されたノート' })).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: '更新' })).toBeVisible();
     
     // Initially should show "no notes" message (might take time to load)
     await expect(page.locator('text=まだノートがありません')).toBeVisible({ timeout: 10000 });
@@ -127,8 +127,8 @@ test.describe('Simplenotebook Basic Functionality', () => {
     // Wait for page to be loaded
     await page.waitForSelector('h1', { timeout: 10000 });
     
-    // Check for user display area and sign out button
-    await expect(page.locator('button')).toContainText('サインアウト');
-    await expect(page.locator('button')).toContainText('設定');
+    // Check for user display area and sign out button (button は複数あるため hasText で特定する)
+    await expect(page.locator('button').filter({ hasText: 'サインアウト' })).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: '設定' })).toBeVisible();
   });
 });

--- a/tests/dev-server-functionality.spec.ts
+++ b/tests/dev-server-functionality.spec.ts
@@ -103,9 +103,9 @@ test.describe('Simplenotebook - Development Server', () => {
     // Wait for page to be loaded
     await page.waitForSelector('h1', { timeout: 15000 });
     
-    // Check for saved notes section
-    await expect(page.locator('h2')).toContainText('保存されたノート');
-    await expect(page.locator('button')).toContainText('更新');
+    // Check for saved notes section (h2/button は複数あるため hasText で特定する)
+    await expect(page.locator('h2').filter({ hasText: '保存されたノート' })).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: '更新' })).toBeVisible();
     
     // Initially should show "no notes" message
     await expect(page.locator('text=まだノートがありません')).toBeVisible({ timeout: 10000 });
@@ -117,9 +117,9 @@ test.describe('Simplenotebook - Development Server', () => {
     // Wait for page to be loaded
     await page.waitForSelector('h1', { timeout: 15000 });
     
-    // Check for user display area and buttons
-    await expect(page.locator('button')).toContainText('サインアウト');
-    await expect(page.locator('button')).toContainText('設定');
+    // Check for user display area and buttons (button は複数あるため hasText で特定する)
+    await expect(page.locator('button').filter({ hasText: 'サインアウト' })).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: '設定' })).toBeVisible();
   });
 
   test('should handle Japanese characters correctly', async ({ page }) => {

--- a/tests/final-working.spec.ts
+++ b/tests/final-working.spec.ts
@@ -28,8 +28,9 @@ test.describe('Simplenotebook - Final Working Tests', () => {
     await expect(page.locator('input[placeholder*="ノートのタイトル"]')).toBeVisible();
     await expect(page.locator('textarea[placeholder*="Markdownを書いてください"]')).toBeVisible();
     
-    // Just check that submit buttons exist (don't be strict about which one)
-    await expect(page.locator('button[type="submit"]')).toHaveCount(2); // One for main form, one for settings
+    // 設定モーダルは開いた時のみレンダリングされるため、submit ボタンはノートフォームの1つだけ
+    await expect(page.locator('button[type="submit"]')).toHaveCount(1);
+    await expect(page.locator('button[type="submit"]')).toContainText('保存');
   });
 
   test('LocalStorageでコンテンツが永続化される', async ({ page }) => {

--- a/tests/fixed-selectors.spec.ts
+++ b/tests/fixed-selectors.spec.ts
@@ -29,7 +29,11 @@ test.describe('Simplenotebook - Fixed Selectors', () => {
     await expect(page.locator('textarea[placeholder*="Markdownを書いてください"]')).toBeVisible();
     
     // Use more specific selector for the main note form submit button
-    const mainFormSubmitButton = page.locator('form').filter({ hasText: 'ノートのタイトル' }).locator('button[type="submit"]');
+    // (hasText は placeholder にマッチしないため、has でタイトル入力欄を含む form を特定する)
+    const mainFormSubmitButton = page
+      .locator('form')
+      .filter({ has: page.locator('input[placeholder*="ノートのタイトル"]') })
+      .locator('button[type="submit"]');
     await expect(mainFormSubmitButton).toBeVisible();
     await expect(mainFormSubmitButton).toContainText('保存');
   });
@@ -48,7 +52,11 @@ test.describe('Simplenotebook - Fixed Selectors', () => {
     await page.fill('textarea[placeholder*="Markdownを書いてください"]', testContent);
     
     // Click the main form submit button (not the settings form)
-    const mainFormSubmitButton = page.locator('form').filter({ hasText: 'ノートのタイトル' }).locator('button[type="submit"]');
+    // (hasText は placeholder にマッチしないため、has でタイトル入力欄を含む form を特定する)
+    const mainFormSubmitButton = page
+      .locator('form')
+      .filter({ has: page.locator('input[placeholder*="ノートのタイトル"]') })
+      .locator('button[type="submit"]');
     await mainFormSubmitButton.click();
     
     // Wait for success message (be flexible with the exact text)
@@ -165,7 +173,8 @@ console.log('日本語コメント');
     await page.setViewportSize({ width: 1200, height: 800 });
     
     // Check that grid layout exists
-    const gridContainer = page.locator('.grid').filter({ hasText: 'ノートのタイトル' });
+    // (hasText は placeholder にマッチしないため、has でタイトル入力欄を含む grid を特定する)
+    const gridContainer = page.locator('.grid').filter({ has: page.locator('input[placeholder*="ノートのタイトル"]') });
     await expect(gridContainer).toBeVisible();
     
     // Test mobile viewport


### PR DESCRIPTION
Closes #78

## 概要
main 時点で失敗していた E2E テスト8件を修繕します。調査の結果、すべてテスト側のセレクタ問題で、プロダクトコードのバグはありませんでした。テストの無効化・削除は行わず、現在の UI に合わせてセレクタと期待値を修正しています。

## 原因と修正内容

| 対象 | 原因 | 修正 |
|---|---|---|
| basic-functionality ×2、dev-server-functionality ×2 | `locator('h2')` / `locator('button')` が複数要素にマッチする strict mode violation | `.filter({ hasText: '...' })` で対象要素を特定 |
| fixed-selectors ×3 | `.filter({ hasText: 'ノートのタイトル' })` が placeholder 属性にマッチしない(hasText は text content のみ対象) | `.filter({ has: locator('input[placeholder*=...]') })` に変更 |
| final-working ×1 | 設定モーダルの submit ボタンが常時レンダリングされる前提の期待値(2個) | モーダルは開いた時のみレンダリングされる現仕様に合わせて1個に修正 |

## テスト
- `npx playwright test` 全56件成功 ✅(修繕前: 48 passed / 8 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)