### PR TITLE
feat: ノートのタグ機能を追加 (B-03)

### DIFF
--- a/app/notes/new/page.tsx
+++ b/app/notes/new/page.tsx
@@ -8,10 +8,13 @@ import { getUserDisplayName } from '../../../utils/userDisplay'
 import UserDisplay from '../../../components/UserDisplay'
 import ThemeToggle from '../../../components/ThemeToggle'
 import SearchBox from '../../../components/SearchBox'
+import TagInput from '../../../components/TagInput'
 
 function NewNotePageContent() {
   const [content, setContent] = useState('')
   const [title, setTitle] = useState('')
+  const [tags, setTags] = useState<string[]>([])
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
   const [message, setMessage] = useState('')
   const [isSaving, setIsSaving] = useState(false)
   const [isProcessingCallback, setIsProcessingCallback] = useState(false)
@@ -24,6 +27,10 @@ function NewNotePageContent() {
   const { user, signOut, isLocal } = useAuth()
   const { notes, loading, error, createNote, updateNote, deleteNote, getNote, fetchNotes } = useNotes()
   const { query, setQuery, filteredNotes, isSearching } = useNoteSearch(notes, getNote)
+  // キーワード検索の結果にタグ絞り込みを重ねる (両方指定時は AND 条件)
+  const visibleNotes = selectedTag
+    ? filteredNotes.filter(note => (note.tags ?? []).includes(selectedTag))
+    : filteredNotes
 
   // Handle OAuth callback
   useEffect(() => {
@@ -82,6 +89,7 @@ function NewNotePageContent() {
         await updateNote(editingNote, {
           title: title || 'Untitled',
           content,
+          tags,
         })
         setMessage('ノートを更新しました！')
       } else {
@@ -89,6 +97,7 @@ function NewNotePageContent() {
         await createNote({
           title: title || 'Untitled',
           content,
+          tags,
         })
         setMessage(isLocal ? 'ノートを保存しました（ローカル保存）' : 'ノートを保存しました！')
       }
@@ -96,6 +105,7 @@ function NewNotePageContent() {
       // Clear form after successful save
       setContent('')
       setTitle('')
+      setTags([])
       setEditingNote(null)
       window.localStorage.removeItem('new-note-content')
       window.localStorage.removeItem('new-note-title')
@@ -113,6 +123,7 @@ function NewNotePageContent() {
       if (note) {
         setTitle(note.title)
         setContent(note.content)
+        setTags(note.tags ?? [])
         setEditingNote(noteId)
         setMessage('')
       }
@@ -137,6 +148,7 @@ function NewNotePageContent() {
         setEditingNote(null)
         setTitle('')
         setContent('')
+        setTags([])
       }
     } catch (err) {
       setMessage('削除に失敗しました。もう一度お試しください。')
@@ -154,6 +166,7 @@ function NewNotePageContent() {
     setEditingNote(null)
     setTitle('')
     setContent('')
+    setTags([])
     setMessage('')
     window.localStorage.removeItem('new-note-content')
     window.localStorage.removeItem('new-note-title')
@@ -233,6 +246,7 @@ function NewNotePageContent() {
               onChange={e => setTitle(e.target.value)}
               placeholder="ノートのタイトル"
             />
+            <TagInput tags={tags} onChange={setTags} disabled={isSaving} />
             <textarea
               className="w-full h-64 border dark:border-gray-600 rounded p-2 font-mono text-sm bg-white dark:bg-gray-800"
               value={content}
@@ -268,6 +282,21 @@ function NewNotePageContent() {
 
           <SearchBox value={query} onChange={setQuery} />
 
+          {selectedTag && (
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <span>タグで絞り込み:</span>
+              <button
+                type="button"
+                onClick={() => setSelectedTag(null)}
+                aria-label={`タグ「${selectedTag}」の絞り込みを解除`}
+                className="inline-flex items-center gap-1 text-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 rounded-full px-2 py-0.5 hover:bg-blue-200 dark:hover:bg-blue-800"
+                data-testid="active-tag-filter"
+              >
+                {selectedTag} ✕
+              </button>
+            </div>
+          )}
+
           {loading && (
             <div className="text-center text-gray-500 dark:text-gray-400">
               ノートを読み込み中...
@@ -292,8 +321,14 @@ function NewNotePageContent() {
             </div>
           )}
 
+          {notes.length > 0 && filteredNotes.length > 0 && visibleNotes.length === 0 && selectedTag && (
+            <div className="text-gray-500 dark:text-gray-400 text-center" data-testid="tag-no-results">
+              タグ「{selectedTag}」のノートはありません
+            </div>
+          )}
+
           <div className="space-y-2 max-h-96 overflow-y-auto">
-            {filteredNotes.map((note) => (
+            {visibleNotes.map((note) => (
               <div key={note.id} className="border dark:border-gray-700 rounded p-3 hover:bg-gray-50 dark:hover:bg-gray-800">
                 <div className="flex justify-between items-start">
                   <div className="flex-1">
@@ -306,6 +341,22 @@ function NewNotePageContent() {
                         </span>
                       )}
                     </p>
+                    {(note.tags ?? []).length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {(note.tags ?? []).map(tag => (
+                          <button
+                            key={tag}
+                            type="button"
+                            onClick={() => setSelectedTag(tag)}
+                            aria-label={`タグ「${tag}」で絞り込み`}
+                            className="text-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 rounded-full px-2 py-0.5 hover:bg-blue-200 dark:hover:bg-blue-800"
+                            data-testid="note-tag"
+                          >
+                            {tag}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                   </div>
                   <div className="flex space-x-2 ml-2">
                     <button

--- a/cdk/lambda/index.ts
+++ b/cdk/lambda/index.ts
@@ -10,8 +10,30 @@ interface Note {
   id: string;
   title: string;
   content: string;
+  tags?: string[];
   createdAt: string;
   updatedAt: string;
+}
+
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
+// タグの入力サニタイゼーション: 文字列配列以外は空に、trim・空要素除去・重複排除・件数/長さ制限
+function sanitizeTags(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== 'string') continue;
+    const tag = raw.trim().slice(0, MAX_TAG_LENGTH);
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    tags.push(tag);
+    if (tags.length >= MAX_TAGS) break;
+  }
+  return tags;
 }
 
 interface UserSettings {
@@ -123,6 +145,7 @@ async function listNotes(userPrefix: string): Promise<APIGatewayProxyResult> {
       return {
         id: noteId,
         title: note.title,
+        tags: note.tags ?? [],
         createdAt: note.createdAt,
         updatedAt: note.updatedAt,
       };
@@ -147,6 +170,7 @@ async function createNote(userPrefix: string, noteData: Partial<Note>): Promise<
     id: noteId,
     title: noteData.title || 'Untitled',
     content: noteData.content || '',
+    tags: sanitizeTags(noteData.tags),
     createdAt: now,
     updatedAt: now,
   };
@@ -249,6 +273,7 @@ async function updateNote(userPrefix: string, noteId?: string, noteData?: Partia
       ...existingNote,
       ...noteData,
       id: existingNote.id, // Prevent ID change
+      tags: noteData?.tags !== undefined ? sanitizeTags(noteData.tags) : existingNote.tags ?? [],
       createdAt: existingNote.createdAt, // Prevent creation date change
       updatedAt: new Date().toISOString(),
     };

--- a/cdk/lambda/index.ts
+++ b/cdk/lambda/index.ts
@@ -17,6 +17,8 @@ interface Note {
 
 const MAX_TAGS = 20;
 const MAX_TAG_LENGTH = 50;
+// 無効要素だけの巨大配列で全件走査させられないよう、走査自体にも上限を設ける
+const MAX_TAG_SCAN = 100;
 
 // タグの入力サニタイゼーション: 文字列配列以外は空に、trim・空要素除去・重複排除・件数/長さ制限
 function sanitizeTags(input: unknown): string[] {
@@ -25,7 +27,7 @@ function sanitizeTags(input: unknown): string[] {
   }
   const seen = new Set<string>();
   const tags: string[] = [];
-  for (const raw of input) {
+  for (const raw of input.slice(0, MAX_TAG_SCAN)) {
     if (typeof raw !== 'string') continue;
     const tag = raw.trim().slice(0, MAX_TAG_LENGTH);
     if (!tag || seen.has(tag)) continue;
@@ -145,7 +147,8 @@ async function listNotes(userPrefix: string): Promise<APIGatewayProxyResult> {
       return {
         id: noteId,
         title: note.title,
-        tags: note.tags ?? [],
+        // S3 上のデータが壊れていても型不整合を返さないよう読み出し側でも正規化する
+        tags: sanitizeTags(note.tags),
         createdAt: note.createdAt,
         updatedAt: note.updatedAt,
       };
@@ -273,7 +276,8 @@ async function updateNote(userPrefix: string, noteId?: string, noteData?: Partia
       ...existingNote,
       ...noteData,
       id: existingNote.id, // Prevent ID change
-      tags: noteData?.tags !== undefined ? sanitizeTags(noteData.tags) : existingNote.tags ?? [],
+      // 既存データ側が壊れている場合も含めて、保存前に必ず正規化する
+      tags: sanitizeTags(noteData?.tags !== undefined ? noteData.tags : existingNote.tags),
       createdAt: existingNote.createdAt, // Prevent creation date change
       updatedAt: new Date().toISOString(),
     };

--- a/components/TagInput.tsx
+++ b/components/TagInput.tsx
@@ -23,8 +23,13 @@ export default function TagInput({ tags, onChange, disabled = false }: TagInputP
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
-    // IME 変換確定の Enter でタグ追加されないよう composition 中は無視する
-    if (e.nativeEvent.isComposing) return;
+    // IME 変換確定の Enter ではタグ追加せず、フォーム submit も抑止する
+    if (e.nativeEvent.isComposing) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
+      return;
+    }
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
       addTag();

--- a/components/TagInput.tsx
+++ b/components/TagInput.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState, KeyboardEvent } from 'react';
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  disabled?: boolean;
+}
+
+export default function TagInput({ tags, onChange, disabled = false }: TagInputProps) {
+  const [input, setInput] = useState('');
+
+  function addTag() {
+    const tag = input.trim();
+    setInput('');
+    if (!tag || tags.includes(tag)) return;
+    onChange([...tags, tag]);
+  }
+
+  function removeTag(tag: string) {
+    onChange(tags.filter(t => t !== tag));
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    // IME 変換確定の Enter でタグ追加されないよう composition 中は無視する
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag();
+    } else if (e.key === 'Backspace' && input === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 w-full border dark:border-gray-600 rounded p-2 bg-white dark:bg-gray-800"
+      data-testid="tag-input"
+    >
+      {tags.map(tag => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 text-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 rounded-full px-2 py-0.5"
+          data-testid="tag-chip"
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={() => removeTag(tag)}
+            aria-label={`タグ「${tag}」を削除`}
+            className="hover:text-blue-600 dark:hover:text-blue-100"
+            disabled={disabled}
+          >
+            ✕
+          </button>
+        </span>
+      ))}
+      <input
+        type="text"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={addTag}
+        placeholder={tags.length === 0 ? 'タグを追加 (Enter で確定)' : ''}
+        aria-label="タグを追加"
+        className="flex-1 min-w-24 text-sm bg-transparent outline-none"
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/hooks/useNotes.ts
+++ b/hooks/useNotes.ts
@@ -28,6 +28,7 @@ export function useNotes() {
       setNotes(prev => [...prev, {
         id: response.note.id,
         title: response.note.title,
+        tags: response.note.tags ?? [],
         createdAt: response.note.createdAt,
         updatedAt: response.note.updatedAt,
       }]);
@@ -42,11 +43,12 @@ export function useNotes() {
     setError(null);
     try {
       const response = await apiClient.updateNote(id, noteData);
-      setNotes(prev => prev.map(note => 
-        note.id === id 
+      setNotes(prev => prev.map(note =>
+        note.id === id
           ? {
               id: response.note.id,
               title: response.note.title,
+              tags: response.note.tags ?? [],
               createdAt: response.note.createdAt,
               updatedAt: response.note.updatedAt,
             }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,6 +5,8 @@ export interface Note {
   id: string;
   title: string;
   content: string;
+  /** 旧データにはフィールド自体が存在しないため optional (タグなしは [] 扱い) */
+  tags?: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/lib/localApi.ts
+++ b/lib/localApi.ts
@@ -27,6 +27,7 @@ export class LocalApiClient {
       notes: notes.map(note => ({
         id: note.id,
         title: note.title,
+        tags: note.tags ?? [],
         createdAt: note.createdAt,
         updatedAt: note.updatedAt,
       })),
@@ -52,6 +53,7 @@ export class LocalApiClient {
       id: generateNoteId(),
       title: noteData.title || 'Untitled',
       content: noteData.content || '',
+      tags: noteData.tags ?? [],
       createdAt: now,
       updatedAt: now,
     };
@@ -75,6 +77,7 @@ export class LocalApiClient {
       ...existingNote,
       title: noteData.title !== undefined ? noteData.title : existingNote.title,
       content: noteData.content !== undefined ? noteData.content : existingNote.content,
+      tags: noteData.tags !== undefined ? noteData.tags : existingNote.tags ?? [],
       updatedAt: new Date().toISOString(),
     };
     

--- a/tests/note-tags.spec.ts
+++ b/tests/note-tags.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, Page } from '@playwright/test';
+import { seedUserSettings } from './helpers/seedUserSettings';
+import { appPath } from './helpers/paths';
+
+async function createNoteWithTags(page: Page, title: string, content: string, tags: string[]) {
+  await page.fill('input[placeholder*="ノートのタイトル"]', title);
+  await page.fill('textarea[placeholder*="Markdownを書いてください"]', content);
+  for (const tag of tags) {
+    await page.getByLabel('タグを追加').fill(tag);
+    await page.getByLabel('タグを追加').press('Enter');
+  }
+  await page.click('button[type="submit"]');
+  await expect(page.locator('text=保存しました')).toBeVisible();
+}
+
+test.describe('Note Tags (B-03)', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedUserSettings(page);
+    await page.goto(appPath('/notes/new'));
+    await expect(page.locator('h1')).toContainText('SimpleNotebook');
+  });
+
+  test('タグを付与して保存すると一覧にタグが表示される', async ({ page }) => {
+    await createNoteWithTags(page, '仕事メモ', '会議の議事録', ['仕事', '会議']);
+
+    const card = page.locator('.border.rounded').filter({ hasText: '仕事メモ' });
+    await expect(card.getByTestId('note-tag').filter({ hasText: '仕事' })).toBeVisible();
+    await expect(card.getByTestId('note-tag').filter({ hasText: '会議' })).toBeVisible();
+  });
+
+  test('タグクリックで絞り込まれ、解除で全件に戻る', async ({ page }) => {
+    await createNoteWithTags(page, '仕事メモ', '会議の議事録', ['仕事']);
+    await createNoteWithTags(page, '買い物リスト', '- 牛乳', ['プライベート']);
+
+    // タグ「仕事」で絞り込み
+    await page.getByTestId('note-tag').filter({ hasText: '仕事' }).click();
+    await expect(page.getByTestId('active-tag-filter')).toContainText('仕事');
+    await expect(page.locator('h3', { hasText: '仕事メモ' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '買い物リスト' })).not.toBeVisible();
+
+    // 絞り込み解除で全件表示
+    await page.getByTestId('active-tag-filter').click();
+    await expect(page.locator('h3', { hasText: '仕事メモ' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '買い物リスト' })).toBeVisible();
+  });
+
+  test('編集でタグを追加・削除できる', async ({ page }) => {
+    await createNoteWithTags(page, '編集対象', '本文', ['旧タグ']);
+
+    // 編集モードに入るとタグが復元される
+    await page.locator('.border.rounded').filter({ hasText: '編集対象' }).getByRole('button', { name: '編集' }).click();
+    await expect(page.getByTestId('tag-input').getByTestId('tag-chip').filter({ hasText: '旧タグ' })).toBeVisible();
+
+    // 旧タグを削除して新タグを追加
+    await page.getByLabel('タグ「旧タグ」を削除').click();
+    await page.getByLabel('タグを追加').fill('新タグ');
+    await page.getByLabel('タグを追加').press('Enter');
+    await page.click('button[type="submit"]');
+    await expect(page.locator('text=ノートを更新しました')).toBeVisible();
+
+    const card = page.locator('.border.rounded').filter({ hasText: '編集対象' });
+    await expect(card.getByTestId('note-tag').filter({ hasText: '新タグ' })).toBeVisible();
+    await expect(card.getByTestId('note-tag').filter({ hasText: '旧タグ' })).not.toBeVisible();
+  });
+
+  test('タグがリロード後も維持される', async ({ page }) => {
+    await createNoteWithTags(page, '永続化テスト', '本文', ['保持タグ']);
+
+    await page.reload();
+    await expect(page.locator('h1')).toContainText('SimpleNotebook');
+
+    const card = page.locator('.border.rounded').filter({ hasText: '永続化テスト' });
+    await expect(card.getByTestId('note-tag').filter({ hasText: '保持タグ' })).toBeVisible();
+  });
+
+  test('検索とタグ絞り込みを併用できる (AND 条件)', async ({ page }) => {
+    await createNoteWithTags(page, '会議メモA', 'スプリント計画', ['仕事']);
+    await createNoteWithTags(page, '会議メモB', '雑談', ['仕事']);
+    await createNoteWithTags(page, '個人メモ', 'スプリント自習', ['プライベート']);
+
+    await page.getByTestId('note-tag').filter({ hasText: '仕事' }).first().click();
+    await page.getByTestId('note-search').fill('スプリント');
+
+    await expect(page.locator('h3', { hasText: '会議メモA' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: '会議メモB' })).not.toBeVisible();
+    await expect(page.locator('h3', { hasText: '個人メモ' })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #79

## 概要
ノートに複数タグを付与・削除でき、一覧でタグによる絞り込みができるようにします。タグはノートデータ(S3)に保存され、デバイス間で同期されます。

## 変更内容

### データ層
- `lib/api.ts`: `Note` に `tags?: string[]` を追加(旧データはフィールドなし = タグなし扱いで後方互換)
- `cdk/lambda/index.ts`: `sanitizeTags` による入力サニタイゼーション(型検証・trim・重複排除・最大20件/各50文字)。一覧 API のサマリに `tags` を含め、本文取得なしでタグ表示・絞り込み可能に
- `lib/localApi.ts` / `hooks/useNotes.ts`: ローカルモードと一覧ステートのタグ対応

### UI
- `components/TagInput.tsx`: タグ入力(Enter/カンマで追加、IME 変換中の Enter は無視、Backspace で末尾削除)
- ノートカードにタグチップを表示、クリックでタグ絞り込み
- 絞り込み中はインジケータ表示、✕ で解除
- キーワード検索(B-01)とは AND 条件で併用可
- ダークモード対応済み

## テスト
- `npm run lint` / `npm run build` / `cdk の tsc` ✅
- 新規 E2E 5件(付与/絞り込み+解除/編集での追加・削除/リロード永続化/検索との併用)✅
- 関連 E2E 18件(検索・ダークモード・ノート管理・タグ)すべて成功 ✅
- ブラウザ実機確認: タグ「重要」を付与して保存 → カードにチップ表示 → クリックで1件に絞り込み+インジケータ表示を確認 ✅

## 備考
- S3 のユーザー分離・既存のセキュリティ設定には変更なし(ノート JSON にフィールドが増えるのみ)
- 既存 E2E の既知失敗8件は #81 (B-13) で修繕済み(本 PR とファイル重複なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)